### PR TITLE
Use requests Session objects.

### DIFF
--- a/ovh/client.py
+++ b/ovh/client.py
@@ -45,7 +45,7 @@ except ImportError: # pragma: no cover
     # Python 3
     from urllib.parse import urlencode
 
-from requests import request
+from requests import request, Session
 from requests.exceptions import RequestException
 
 from .config import config
@@ -146,6 +146,9 @@ class Client(object):
 
         # lazy load time delta
         self._time_delta = None
+
+        # use a requests session to reuse HTTPS connections between requests
+        self._session = Session()
 
     ## high level API
 
@@ -311,7 +314,8 @@ class Client(object):
 
         # attempt request
         try:
-            result = request(method, target, headers=headers, data=body)
+            result = self._session.request(method, target, headers=headers,
+                                           data=body)
         except RequestException as error:
             raise HTTPError("Low HTTP request failed error", error)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -182,7 +182,7 @@ class testClient(unittest.TestCase):
 
     ## test core function
 
-    @mock.patch('ovh.client.request')
+    @mock.patch('ovh.client.Session.request')
     def test_call_no_sign(self, m_req):
         m_res = m_req.return_value
         m_json = m_res.json.return_value
@@ -236,7 +236,7 @@ class testClient(unittest.TestCase):
         m_res.status_code = 306
         self.assertRaises(APIError, api.call, FAKE_METHOD, FAKE_PATH, None, False)
 
-    @mock.patch('ovh.client.request')
+    @mock.patch('ovh.client.Session.request')
     @mock.patch('ovh.client.Client.time_delta', new_callable=mock.PropertyMock)
     def test_call_signature(self, m_time_delta, m_req):
         m_res = m_req.return_value


### PR DESCRIPTION
This change allows to re-use HTTPS connections between client requests
by using a single Session object to handle all HTTPS requests.
