### PR TITLE
CI: migrate to new travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ install:
 script: nosetests
 after_success:
     coveralls
+sudo: false
 


### PR DESCRIPTION
Migrate to new Docker based Travis infrastructure. See: http://docs.travis-ci.com/user/migrating-from-legacy/. This makes sense since we do not need root.