### PR TITLE
Read custom file on runtime

### DIFF
--- a/ovh/client.py
+++ b/ovh/client.py
@@ -104,7 +104,8 @@ class Client(object):
     """
 
     def __init__(self, endpoint=None, application_key=None,
-                 application_secret=None, consumer_key=None, timeout=TIMEOUT):
+                 application_secret=None, consumer_key=None, timeout=TIMEOUT,
+                 config_file=None):
         """
         Creates a new Client. No credential check is done at this point.
 
@@ -134,6 +135,11 @@ class Client(object):
         :param float timeout: Same timeout for both connection and read
         :raises InvalidRegion: if ``endpoint`` can't be found in ``ENDPOINTS``.
         """
+        # Load a custom config file is requested
+        if config_file is not None:
+            config.read(config_file)
+            print("toto")
+
         # load endpoint
         if endpoint is None:
             endpoint = config.get('default', 'endpoint')

--- a/ovh/client.py
+++ b/ovh/client.py
@@ -138,7 +138,6 @@ class Client(object):
         # Load a custom config file is requested
         if config_file is not None:
             config.read(config_file)
-            print("toto")
 
         # load endpoint
         if endpoint is None:

--- a/ovh/config.py
+++ b/ovh/config.py
@@ -117,5 +117,9 @@ class ConfigurationManager(object):
         # not found, sorry
         return None
 
+    def read(self, config_file):
+        # Read an other config file
+        self.config.read(config_file)
+
 #: System wide instance :py:class:`ConfigurationManager` instance
 config = ConfigurationManager()


### PR DESCRIPTION
This patch provide a way to read custom config file that can be provided
on runtime.
E.G.:
  client = ovh.Client(config_file="ovh.custom.conf")

This is useful when you have to switch from multiple config file.
At least, this is useful to me :p