### PR TITLE
Add example to get services that will expired

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,11 @@
+Python wrapper examples
+-----------------------
+
+In this part, you can find and share real use cases for the OVH python wrapper
+
+## OVH services
+
+Following examples are related to cross services proposed by OVH.
+
+ - [How to get services that will expired soon?](serviceExpiration/api_get_service_that_expired_soon.md)
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,11 +1,11 @@
 Python wrapper examples
 -----------------------
 
-In this part, you can find and share real use cases for the OVH python wrapper
+In this part, you can find real use cases for the OVH Python wrapper
 
 ## OVH services
 
 Following examples are related to cross services proposed by OVH.
 
- - [How to get services that will expired soon?](serviceExpiration/api_get_service_that_expired_soon.md)
+ - [How to get the list of services expiring soon?](serviceExpiration/api_get_service_that_expired_soon.md)
 

--- a/examples/serviceExpiration/api_get_service_that_expired_soon.md
+++ b/examples/serviceExpiration/api_get_service_that_expired_soon.md
@@ -1,7 +1,7 @@
-How to get services that will expired soon with python wrapper?
----------------------------------------------------------------
+How to get list of services expiring soon with Python wrapper?
+--------------------------------------------------------------
 
-This documentation will help you to know what services will be expired soon and need to be renew. Following script will check each of your OVH services and check expiration date.
+This documentation will help you to list what services will be expired soon and need to be renew. The following script will check the expiration date of each services attached to your consumer_key
 
 ## Requirements
 
@@ -39,7 +39,7 @@ If you need a more generic token, you may adjust the **Rights** fields at your n
 
 ## Download the script
 
-- Download and edit the python file to get service that will expired. You can download [this file](serviceThatWillExpired.py). By default, delay is defined as 60 days. You can edit the script to change the delay.
+- Download and edit the python file to get service that will expired. You can download [this file](serviceThatWillExpired.py). By default, delay is defined as 60 days. You can edit the script to change the ```delay```.
 
 ## Run script
 

--- a/examples/serviceExpiration/api_get_service_that_expired_soon.md
+++ b/examples/serviceExpiration/api_get_service_that_expired_soon.md
@@ -1,0 +1,64 @@
+How to get services that will expired soon with python wrapper?
+---------------------------------------------------------------
+
+This documentation will help you to know what services will be expired soon and need to be renew. Following script will check each of your OVH services and check expiration date.
+
+## Requirements
+
+- Having an OVH Account with services inside
+
+## Install Python wrapper
+
+The easiest way to get the latest stable release is to grab it from pypi using ```pip```.
+
+```bash
+pip install tabulate ovh
+```
+
+## Create a new token
+
+You can create a new token using this url: [https://api.ovh.com/createToken/?GET=/*](https://api.ovh.com/createToken/?GET=/*).
+Keep application key, application secret and consumer key and replace default values in ```ovh.conf``` file.
+
+```ini
+[default]
+; general configuration: default endpoint
+endpoint=ovh-eu
+
+[ovh-eu]
+; configuration specific to 'ovh-eu' endpoint
+application_key=my_app_key
+application_secret=my_application_secret
+; uncomment following line when writing a script application
+; with a single consumer key.
+consumer_key=my_consumer_key
+```
+
+Be warned, this token is only valid to get informations of your OVH services. You cannot changes or delete your products with it.
+If you need a more generic token, you may adjust the **Rights** fields at your needs.
+
+## Download the script
+
+- Download and edit the python file to get service that will expired. You can download [this file](serviceThatWillExpired.py). By default, delay is defined as 60 days. You can edit the script to change the delay.
+
+## Run script
+
+```bash
+python serviceThatWillExpired.py
+```
+
+For instance, using the example values in this script, the answer would look like:
+```bash
+Type                     ID                                status    expiration date
+-----------------------  --------------------------------  --------  -----------------
+cdn/webstorage           cdnstatic-no42-1337               ok        2016-02-14
+cloud/project            42xxxxxxxxxxxxxxxxxxxxxxxxxxx42   expired   2016-01-30
+hosting/privateDatabase  no42-001                          ok        2016-02-15
+license/office           office42.o365.ovh.com             ok        2016-02-15
+router                   router-rbx-1-sdr-1337             expired   2016-01-31
+```
+
+## What's more?
+
+You can discover all OVH possibilities by using API console to show all available endpoints: [https://api.ovh.com/console](https://api.ovh.com/console)
+

--- a/examples/serviceExpiration/serviceThatWillExpired.py
+++ b/examples/serviceExpiration/serviceThatWillExpired.py
@@ -1,0 +1,74 @@
+# -*- encoding: utf-8 -*-
+
+import datetime
+from tabulate import tabulate
+import ovh
+
+# Services type desired to mine. To speed up the script, delete service type you don't use!
+service_types 	= [ 
+	'allDom',
+	'cdn/dedicated',
+	'cdn/website',
+	'cdn/webstorage',
+	'cloud/project',
+	'cluster/hadoop',
+	'dedicated/housing',
+	'dedicated/nas',
+	'dedicated/nasha',
+	'dedicated/server',
+	'dedicatedCloud',
+	'domain/zone',
+	'email/domain',
+	'email/exchange',
+	'freefax',
+	'hosting/privateDatabase',
+	'hosting/web',
+	'hosting/windows',
+	'hpcspot',
+	'license/cloudLinux',
+	'license/cpanel',
+	'license/directadmin',
+	'license/office',
+	'license/plesk',
+	'license/sqlserver',
+	'license/virtuozzo',
+	'license/windows',
+	'license/worklight',
+	'overTheBox',
+	'pack/xdsl',
+	'partner',
+	'router',
+	'sms',
+	'telephony',
+	'telephony/spare',
+	'veeamCloudConnect',
+	'vps',
+	'xdsl',
+	'xdsl/spare',
+]
+# Delay before expiration in days
+delay = 60
+
+# Create a client using ovh.conf
+client = ovh.Client()
+
+# Compute now + delay
+delay_date = datetime.datetime.now() + datetime.timedelta(days=delay)
+
+services_will_expired = []
+
+# Checking all OVH product (service type)
+for service_type in service_types:
+	service_list = client.get('/%s' % service_type )
+
+	# If we found you have this one or more of this product, we get these informations
+	for service in service_list:
+		service_infos = client.get('/%s/%s/serviceInfos' % (service_type, service) )
+		service_expiration_date = datetime.datetime.strptime(service_infos['expiration'], '%Y-%m-%d')
+
+		# If the expiration date is before (now + delay) date, we add it into our listing
+		if service_expiration_date < delay_date:
+			services_will_expired.append( [ service_type, service, service_infos['status'], service_infos['expiration'] ] )
+			
+# At the end, we show service expirated or that will expirated (in a table with tabulate)
+print tabulate(services_will_expired, headers=['Type', 'ID', 'status', 'expiration date'])

--- a/examples/serviceExpiration/serviceThatWillExpired.py
+++ b/examples/serviceExpiration/serviceThatWillExpired.py
@@ -57,7 +57,7 @@ delay_date = datetime.datetime.now() + datetime.timedelta(days=delay)
 
 services_will_expired = []
 
-# Checking all OVH product (service type)
+# Check all OVH product (service type)
 for service_type in service_types:
 	service_list = client.get('/%s' % service_type )
 


### PR DESCRIPTION
In replacement of http://www.ovh.com/soapi/en/?method=billingGetReferencesToExpired
(and with all current ovh products)