### PR TITLE
Fix: include the vendorized packages and package data in the install process

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,17 @@ keywords =
     rest
 
 [files]
-packages = ovh
+packages =
+    ovh
+    ovh.vendor
+    ovh.vendor.requests
+    ovh.vendor.requests.packages
+    ovh.vendor.requests.packages.urllib3
+    ovh.vendor.requests.packages.urllib3.util
+    ovh.vendor.requests.packages.urllib3.contrib
+    ovh.vendor.requests.packages.urllib3.packages
+    ovh.vendor.requests.packages.urllib3.packages.ssl_match_hostname
+    ovh.vendor.requests.packages.chardet
 
 [test]
 test-suite = nose.collector

--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,13 @@ except ImportError:
     use_setuptools()
     from setuptools import setup
 
+
 setup(
     setup_requires=['d2to1'],
     d2to1=True,
+    package_data={
+        '': ['*.pem'],
+    },
     tests_require=[
         "coverage==3.7.1",
         "mock==1.0.1",
@@ -17,4 +21,3 @@ setup(
         "yanc==0.2.4",
     ],
 )
-


### PR DESCRIPTION
Some collegues from Lyon told me that recent (0.4.0) ovh package broke after install, as no vendor was installed along.

I packaged the vendors in the tarball, and made sure to add the pem certificate bundle.