### PR TITLE
fix: d2to1 can now be a version superior to 0.2.11

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ license = BSD
 platforms = "Posix; MacOS X; Windows"
 requires-dist =
     setuptools
-    d2to1==0.2.11
+    d2to1>=0.2.11
 classifier =
     License :: OSI Approved :: BSD License
     Development Status :: 4 - Beta


### PR DESCRIPTION
Hello,

I had the same issue than #25 when I tried to install the OVH API on Archlinux. This patch solved it.

Regards,

-- 
Mathis 'hasB4K' FELARDOS