### PR TITLE
Read custom file on runtime

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -354,9 +354,31 @@ Running is only a simple command line:
 Configuration
 =============
 
+You have 3 ways to provide configuration to the client:
+ - write it directly in the application code
+ - read environment variables or predefined configuration files
+ - read it from a custom configuration file
+
+Embed the configuration in the code
+-----------------------------------
+
 The straightforward way to use OVH's API keys is to embed them directly in the
 application code. While this is very convenient, it lacks of elegance and
 flexibility.
+
+Example usage:
+
+.. code:: python
+
+    client = ovh.Client(
+        endpoint='ovh-eu',
+        application_key='<application key>',
+        application_secret='<application secret>',
+        consumer_key='<consumer key>',
+    )
+
+Environment vars and predefined configuration files
+---------------------------------------------------
 
 Alternatively it is suggested to use configuration files or environment
 variables so that the same code may run seamlessly in multiple environments.
@@ -387,6 +409,24 @@ The client will successively attempt to locate this configuration file in
 
 This lookup mechanism makes it easy to overload credentials for a specific
 project or user.
+
+Example usage:
+
+.. code:: python
+
+    client = ovh.Client()
+
+Custom configuration file
+-------------------------
+
+You can also specify a custom configuration file. With this method, you won't be able to inherit values from environment.
+
+Example usage:
+
+.. code:: python
+
+    client = ovh.Client(config_file='/my/config.conf')
+
 
 Passing parameters
 ==================

--- a/ovh/client.py
+++ b/ovh/client.py
@@ -113,7 +113,8 @@ class Client(object):
     """
 
     def __init__(self, endpoint=None, application_key=None,
-                 application_secret=None, consumer_key=None, timeout=TIMEOUT):
+                 application_secret=None, consumer_key=None, timeout=TIMEOUT,
+                 config_file=None):
         """
         Creates a new Client. No credential check is done at this point.
 
@@ -143,6 +144,10 @@ class Client(object):
         :param float timeout: Same timeout for both connection and read
         :raises InvalidRegion: if ``endpoint`` can't be found in ``ENDPOINTS``.
         """
+        # Load a custom config file if requested
+        if config_file is not None:
+            config.read(config_file)
+
         # load endpoint
         if endpoint is None:
             endpoint = config.get('default', 'endpoint')

--- a/ovh/config.py
+++ b/ovh/config.py
@@ -117,5 +117,9 @@ class ConfigurationManager(object):
         # not found, sorry
         return None
 
+    def read(self, config_file):
+        # Read an other config file
+        self.config.read(config_file)
+
 #: System wide instance :py:class:`ConfigurationManager` instance
 config = ConfigurationManager()

--- a/tests/fixtures/custom_ovh.conf
+++ b/tests/fixtures/custom_ovh.conf
@@ -1,0 +1,8 @@
+[default]
+; custom configuration: default endpoint
+endpoint=ovh-ca
+
+[ovh-ca]
+application_key=This is a fake custom application key
+application_secret=This is a *real* custom application key
+consumer_key=I am customingly kidding

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -52,6 +52,8 @@ M_ENVIRON = {
     'OVH_CONSUMER_KEY': 'consumer key from from environ',
 }
 
+M_CUSTOM_CONFIG_PATH = './fixtures/custom_ovh.conf'
+
 APPLICATION_KEY = 'fake application key'
 APPLICATION_SECRET = 'fake application secret'
 CONSUMER_KEY = 'fake consumer key'
@@ -102,6 +104,15 @@ class testClient(unittest.TestCase):
         self.assertEqual(M_ENVIRON['OVH_APPLICATION_KEY'],    api._application_key)
         self.assertEqual(M_ENVIRON['OVH_APPLICATION_SECRET'], api._application_secret)
         self.assertEqual(M_ENVIRON['OVH_CONSUMER_KEY'],       api._consumer_key)
+
+    def test_init_from_custom_config(self):
+        # custom config file
+        api = Client(config_file=M_CUSTOM_CONFIG_PATH)
+
+        self.assertEqual('https://ca.api.ovh.com/1.0', api._endpoint)
+        self.assertEqual('This is a fake custom application key', api._application_key)
+        self.assertEqual('This is a *real* custom application key', api._application_secret)
+        self.assertEqual('I am customingly kidding', api._consumer_key)
 
     @mock.patch.object(Client, 'call')
     def test_time_delta(self, m_call):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -37,6 +37,8 @@ M_CONFIG_PATH = [
     './fixtures/pwd_ovh.conf',
 ]
 
+M_CUSTOM_CONFIG_PATH = './fixtures/custom_ovh.conf'
+
 M_ENVIRON = {
     'OVH_ENDPOINT': 'endpoint from environ',
     'OVH_APPLICATION_KEY': 'application key from environ',
@@ -89,4 +91,14 @@ class testConfig(unittest.TestCase):
             self.assertEqual(M_ENVIRON['OVH_APPLICATION_SECRET'], conf.get('wathever', 'application_secret'))
             self.assertEqual(M_ENVIRON['OVH_CONSUMER_KEY'],       conf.get('wathever', 'consumer_key'))
 
+        self.assertTrue(conf.get('ovh-eu', 'non-existent') is None)
+
+    def test_config_get_custom_conf(self):
+        conf = config.ConfigurationManager()
+        conf.read(M_CUSTOM_CONFIG_PATH)
+
+        self.assertEqual('ovh-ca', conf.get('default', 'endpoint'))
+        self.assertEqual('This is a fake custom application key',   conf.get('ovh-ca', 'application_key'))
+        self.assertEqual('This is a *real* custom application key', conf.get('ovh-ca', 'application_secret'))
+        self.assertEqual('I am customingly kidding',                conf.get('ovh-ca', 'consumer_key'))
         self.assertTrue(conf.get('ovh-eu', 'non-existent') is None)


### PR DESCRIPTION
This patch provide a way to read custom config file that can be provided
on runtime.
E.G.:
  client = ovh.Client(config_file="ovh.custom.conf")

This is useful when you have to switch from multiple config file.
At least, this is useful to me :p

Signed-off-by: Arnaud Morin <arnaud.morin@corp.ovh.com>