### PR TITLE
fix: api expects lower case boolean value in querystring. Closes #32

### DIFF
--- a/ovh/client.py
+++ b/ovh/client.py
@@ -289,14 +289,24 @@ class Client(object):
         can be prefixed with an underscore. For example, ``from`` argument of
         ``POST /email/domain/{domain}/redirection`` may be replaced by ``_from``
 
+        This function also handles Python booleans which should be serialized
+        using solely lowercase to be recognized by the API.
+
         :param dict kwargs: input kwargs
         :return dict: filtered kawrgs
         """
         arguments = {}
 
         for k, v in kwargs.items():
+            # Handle Python keywork collision
             if k[0] == '_' and k[1:] in keyword.kwlist:
                 k = k[1:]
+
+            # Handle Booleans
+            if isinstance(v, bool):
+                v = str(v).lower()
+
+            # Commit
             arguments[k] = v
 
         return arguments

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -185,6 +185,12 @@ class testClient(unittest.TestCase):
         self.assertEqual(m_call.return_value, api.get(FAKE_URL+'?query=string', param="test"))
         m_call.assert_called_once_with('GET', FAKE_URL+'?query=string&param=test', None, True)
 
+        # boolean arguments
+        m_call.reset_mock()
+        api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET, CONSUMER_KEY)
+        self.assertEqual(m_call.return_value, api.get(FAKE_URL+'?query=string', checkbox=True))
+        m_call.assert_called_once_with('GET', FAKE_URL+'?query=string&checkbox=true', None, True)
+
         # keyword calling convention
         m_call.reset_mock()
         api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET, CONSUMER_KEY)


### PR DESCRIPTION
OVH API expects Boolean values in the querystring to be sent as lower case 'true' or 'false' string. Such cases are typically represented as checkboxes in https://api.ovh.com/console. This PR adds the fix and the related regression test.

@ncrocfer Can you confirm this fixes your issue before I can merge?