### PR TITLE
fix: (regression) body boolean must be sent as boolean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # execution artefacts
+*.swp
 *.pyc
 .coverage
 

--- a/ovh/client.py
+++ b/ovh/client.py
@@ -289,27 +289,34 @@ class Client(object):
         can be prefixed with an underscore. For example, ``from`` argument of
         ``POST /email/domain/{domain}/redirection`` may be replaced by ``_from``
 
-        This function also handles Python booleans which should be serialized
-        using solely lowercase to be recognized by the API.
-
         :param dict kwargs: input kwargs
         :return dict: filtered kawrgs
         """
         arguments = {}
 
         for k, v in kwargs.items():
-            # Handle Python keywork collision
             if k[0] == '_' and k[1:] in keyword.kwlist:
                 k = k[1:]
-
-            # Handle Booleans
-            if isinstance(v, bool):
-                v = str(v).lower()
-
-            # Commit
             arguments[k] = v
 
         return arguments
+
+    def _prepare_query_string(self, kwargs):
+        """
+        Boolean needs to be send as lowercase 'false' or 'true' in querystring.
+        This function prepares arguments for querystring and encodes them.
+
+        :param dict kwargs: input kwargs
+        :return string: prepared querystring
+        """
+        arguments = {}
+
+        for k, v in kwargs.items():
+            if isinstance(v, bool):
+                v = str(v).lower()
+            arguments[k] = v
+
+        return urlencode(arguments)
 
     def get(self, _target, _need_auth=True, **kwargs):
         """
@@ -325,7 +332,7 @@ class Client(object):
         """
         if kwargs:
             kwargs = self._canonicalize_kwargs(kwargs)
-            query_string = urlencode(kwargs)
+            query_string = self._prepare_query_string(kwargs)
             if '?' in _target:
                 _target = '%s&%s' % (_target, query_string)
             else:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -213,6 +213,7 @@ class testClient(unittest.TestCase):
             'arg1': object(),
             'arg2': object(),
             'arg3': object(),
+            'arg4': False,
         }
 
         api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET, CONSUMER_KEY)
@@ -225,6 +226,7 @@ class testClient(unittest.TestCase):
             'arg1': object(),
             'arg2': object(),
             'arg3': object(),
+            'arg4': False,
         }
 
         api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET, CONSUMER_KEY)


### PR DESCRIPTION
Previous fix introduced a regression. It escaped *all* boolean as lower case strings, including the one in the body. This commit fixes this and adds proper regression tests.

See https://twitter.com/aeris22/status/753989860000669696 for original discussion.