### PR TITLE
Mute SNI warnings and upgrade requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+## 0.4.6 (UNRELEASED)
+ - [fix] remove Python SNI warnings, OVH API does not need SNI
+
 ## 0.4.5 (2016-07-18)
  - [fix] (regression) body boolean must be sent as boolean (#34)
 

--- a/ovh/client.py
+++ b/ovh/client.py
@@ -47,6 +47,7 @@ except ImportError: # pragma: no cover
     from urllib.parse import urlencode
 
 from .vendor.requests import request, Session
+from .vendor.requests.packages import urllib3
 from .vendor.requests.exceptions import RequestException
 
 # Disable pyopenssl. It breaks SSL connection pool when SSL connection is
@@ -56,6 +57,10 @@ try:
     pyopenssl.extract_from_urllib3()
 except ImportError:
     pass
+
+# Disable SNI related Warning. The API does not rely on it
+urllib3.disable_warnings(urllib3.exceptions.SNIMissingWarning)
+urllib3.disable_warnings(urllib3.exceptions.SecurityWarning)
 
 from .config import config
 from .consumer_key import ConsumerKeyRequest

--- a/tests/test_consumer_key.py
+++ b/tests/test_consumer_key.py
@@ -27,7 +27,6 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import unittest
-import requests
 import mock
 
 class testConsumerKeyRequest(unittest.TestCase):


### PR DESCRIPTION
SSL warnings are noisy, especially in CLI environments (poke @ncrocfer) and not actually relevant for python-ovh as we know the API has a dedicated IP per cert by design. We also have a vendored request lib so that this setting should not affect the end user. 