### PR TITLE
feat(query-id): add query_id property to exceptions

### DIFF
--- a/ovh/exceptions.py
+++ b/ovh/exceptions.py
@@ -34,7 +34,17 @@ class APIError(Exception):
     """Base OVH API exception, all specific exceptions inherits from it."""
     def __init__(self, *args, **kwargs):
         self.response = kwargs.pop('response', None)
+        if self.response is not None:
+            self.query_id = self.response.headers.get("X-OVH-QUERYID")
+        else:
+            self.query_id = None
         super(APIError, self).__init__(*args, **kwargs)
+
+    def __str__(self):
+        if self.query_id:
+            return "{} \nOVH-Query-ID: {}".format(super(APIError, self).__str__(), self.query_id)
+        else:
+            return super(APIError, self).__str__()
 
 class HTTPError(APIError):
     """Raised when the request fails at a low level (DNS, network, ...)"""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -305,6 +305,24 @@ class testClient(unittest.TestCase):
         m_res.status_code = 306
         self.assertRaises(APIError, api.call, FAKE_METHOD, FAKE_PATH, None, False)
 
+
+    @mock.patch('ovh.client.Session.request')
+    def test_call_query_id(self, m_req):
+        m_res = m_req.return_value
+        m_json = m_res.json.return_value
+        m_res.headers = {"X-OVH-QUERYID": "FR.test1"}
+
+        api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET)
+
+        m_res.status_code = 99
+        self.assertRaises(APIError, api.call, FAKE_METHOD, FAKE_PATH, None, False)
+        try:
+            api.call(FAKE_METHOD, FAKE_PATH, None, False)
+            self.assertEqual(0, 1)   # should fail as method have to raise APIError
+        except APIError as e:
+            self.assertEqual(e.query_id, "FR.test1")
+
+
     @mock.patch('ovh.client.Session.request')
     @mock.patch('ovh.client.Client.time_delta', new_callable=mock.PropertyMock)
     def test_call_signature(self, m_time_delta, m_req):


### PR DESCRIPTION
When it comes to API Exceptions, customers should be able to provide debugging informations in order to be able to track what's wrong on the other side of the API.

X-OVH-QUERYID is here for that. I think we should display that property in APIError class