### PR TITLE
Preserve dict key order

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,13 @@ except ImportError:
     use_setuptools()
     from setuptools import setup, find_packages
 
+# Python 2.6 compatibility
+requirements=[]
+try:
+    from collections import OrderedDict
+except ImportError:
+    requirements=['ordereddict', 'simplejson']
+
 # Read README.rst content
 with open('README.rst') as f:
     readme = f.read()
@@ -16,6 +23,7 @@ setup(
     name = "ovh",
     version = "0.4.5",
     setup_requires=['setuptools'],
+    install_requires=requirements,
     author = "Jean-Tiare Le Bigot",
     author_email = "jean-tiare.le-bigot@corp.ovh.com",
     description = "Official OVH.com API wrapper",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -394,3 +394,11 @@ class testClient(unittest.TestCase):
             auth_time = Client(endpoint).get('/auth/time', _need_auth=False)
             self.assertTrue(auth_time > 0)
 
+    def test_order_cart(self):
+        # This endpoint is nice. It does not require authentication and
+        # triggers most code. This test will be deterministic only if
+        # ``preserve_key_order`` is correctly taken into account
+        expected = ['cartId', 'expire', 'description', 'readOnly', 'items']
+        cart = Client('ovh-eu', preserve_key_order=True).post('/order/cart', ovhSubsidiary='FR', _need_auth=False)
+        self.assertEqual(expected, list(cart.keys()))
+


### PR DESCRIPTION
This PR adds an option to preserve key order in dict. This option is off by default as it potentially impacts performances. Main use case: when writing CLIs (like ovh-cli) or reflexion tools, yo may assume that keys order is meaningful or, at least, is consistent between runs.

Note: getting it to pass the tests on python 2.6 and 3.2 is a pain. Most oddities in PR are caused by this.