### PR TITLE
Remove deprecated runabove API endpoint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,6 @@ to register your application. Depending the API you plan to use, visit:
 - `So you Start North America <https://ca.api.soyoustart.com/createApp/>`_
 - `Kimsufi Europe <https://eu.api.kimsufi.com/createApp/>`_
 - `Kimsufi North America <https://ca.api.kimsufi.com/createApp/>`_
-- `RunAbove <https://api.runabove.com/createApp/>`_
 
 Once created, you will obtain an **application key (AK)** and an **application
 secret (AS)**.
@@ -104,7 +103,6 @@ Depending on the API you want to use, you may set the ``endpoint`` to:
 * ``soyoustart-ca`` for So you Start North America API
 * ``kimsufi-eu`` for Kimsufi Europe API
 * ``kimsufi-ca`` for Kimsufi North America API
-* ``runabove-ca`` for RunAbove API
 
 See Configuration_ for more information on available configuration mechanisms.
 
@@ -554,14 +552,6 @@ Kimsufi North America
 - **Console**: https://ca.api.kimsufi.com/console/
 - **Create application credentials**: https://ca.api.kimsufi.com/createApp/
 - **Create script credentials** (all keys at once): https://ca.api.kimsufi.com/createToken/
-
-Runabove
---------
-
-- **Community support**: https://community.runabove.com/
-- **Console**: https://api.runabove.com/console/
-- **Create application credentials**: https://api.runabove.com/createApp/
-- **High level SDK**: https://github.com/runabove/python-runabove
 
 Related links
 =============

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,7 +67,6 @@ to register your application. Depending the API you plan yo use, visit:
 
 - `OVH Europe <https://eu.api.ovh.com/createApp/>`_
 - `OVH North-America <https://ca.api.ovh.com/createApp/>`_
-- `RunAbove <https://api.runabove.com/createApp/>`_
 
 Once created, you will obtain an **application key (AK)** and an **application
 secret (AS)**.
@@ -97,7 +96,6 @@ Depending on the API you want to use, you may set the ``endpoint`` to:
 
 * ``ovh-eu`` for OVH Europe API
 * ``ovh-ca`` for OVH North-America API
-* ``runabove-ca`` for RunAbove API
 
 See Configuration_ for more inforamtions on available configuration mechanisms.
 
@@ -290,42 +288,6 @@ pretty cool library to pretty print tabular data in a clean and easy way.
 
 >>> pip install tabulate
 
-List Runabove's instance
-------------------------
-
-This example assumes an existing Configuration_ with valid ``application_key``,
-``application_secret`` and ``consumer_key``.
-
-.. code:: python
-
-    # -*- encoding: utf-8 -*-
-
-    import ovh
-    from tabulate import tabulate
-
-    # visit https://api.runabove.com/createApp/ to create your application's credentials
-    client = ovh.Client(endpoint='runabove-ca')
-
-    # get list of all instances
-    instances = client.get('/instance')
-
-    # pretty print instances status
-    table = []
-    for instance in instances:
-        table.append([
-            instance['name'],
-            instance['ip'],
-            instance['region'],
-            instance['status'],
-        ])
-    print tabulate(table, headers=['Name', 'IP', 'Region', 'Status'])
-
-Before running this example, make sure you have the
-`tabulate <https://pypi.python.org/pypi/tabulate>`_ library installed. It's a
-pretty cool library to pretty print tabular data in a clean and easy way.
-
->>> pip install tabulate
-
 Configuration
 =============
 
@@ -451,13 +413,6 @@ OVH North America
 - **Community support**: api-subscribe@ml.ovh.net
 - **Console**: https://ca.api.ovh.com/console
 - **Create application credentials**: https://ca.api.ovh.com/createApp/
-
-Runabove
---------
-
-- **console**: https://api.runabove.com/console/
-- **get application credentials**: https://api.runabove.com/createApp/
-- **high level SDK**: https://github.com/runabove/python-runabove
 
 Related links
 =============

--- a/ovh/client.py
+++ b/ovh/client.py
@@ -78,7 +78,6 @@ ENDPOINTS = {
     'kimsufi-ca': 'https://ca.api.kimsufi.com/1.0',
     'soyoustart-eu': 'https://eu.api.soyoustart.com/1.0',
     'soyoustart-ca': 'https://ca.api.soyoustart.com/1.0',
-    'runabove-ca': 'https://api.runabove.com/1.0',
 }
 
 #: Default timeout for each request. 180 seconds connect, 180 seconds read.

--- a/tests/fixtures/pwd_ovh.conf
+++ b/tests/fixtures/pwd_ovh.conf
@@ -1,9 +1,9 @@
 [default]
 ; general configuration: default endpoint
-endpoint=runabove-ca
+endpoint=soyoustart-ca
 
-[runabove-ca]
-; Runabove is *local*, but OVH-EU is still available
+[soyoustart-ca]
+; Soyoustart is *local*, but OVH-EU is still available
 application_key=This is a fake local application key
 application_secret=This is a *real* local application key
 consumer_key=I am locally kidding

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -46,7 +46,7 @@ from ovh.exceptions import (
 )
 
 M_ENVIRON = {
-    'OVH_ENDPOINT': 'runabove-ca',
+    'OVH_ENDPOINT': 'soyoustart-ca',
     'OVH_APPLICATION_KEY': 'application key from environ',
     'OVH_APPLICATION_SECRET': 'application secret from environ',
     'OVH_CONSUMER_KEY': 'consumer key from from environ',
@@ -100,7 +100,7 @@ class testClient(unittest.TestCase):
         with mock.patch.dict('os.environ', M_ENVIRON):
             api = Client()
 
-        self.assertEqual('https://api.runabove.com/1.0',      api._endpoint)
+        self.assertEqual('https://ca.api.soyoustart.com/1.0',      api._endpoint)
         self.assertEqual(M_ENVIRON['OVH_APPLICATION_KEY'],    api._application_key)
         self.assertEqual(M_ENVIRON['OVH_APPLICATION_SECRET'], api._application_secret)
         self.assertEqual(M_ENVIRON['OVH_CONSUMER_KEY'],       api._consumer_key)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,13 +70,13 @@ class testConfig(unittest.TestCase):
     def test_config_get_conf(self):
         conf = config.ConfigurationManager()
 
-        self.assertEqual('runabove-ca', conf.get('default', 'endpoint'))
+        self.assertEqual('soyoustart-ca', conf.get('default', 'endpoint'))
         self.assertEqual('This is a *fake* global application key',    conf.get('ovh-eu', 'application_key'))
         self.assertEqual('This is a *real* global application secret', conf.get('ovh-eu', 'application_secret'))
         self.assertEqual('I am kidding at home',                      conf.get('ovh-eu', 'consumer_key'))
-        self.assertEqual('This is a fake local application key',   conf.get('runabove-ca', 'application_key'))
-        self.assertEqual('This is a *real* local application key', conf.get('runabove-ca', 'application_secret'))
-        self.assertEqual('I am locally kidding',                   conf.get('runabove-ca', 'consumer_key'))
+        self.assertEqual('This is a fake local application key',   conf.get('soyoustart-ca', 'application_key'))
+        self.assertEqual('This is a *real* local application key', conf.get('soyoustart-ca', 'application_secret'))
+        self.assertEqual('I am locally kidding',                   conf.get('soyoustart-ca', 'consumer_key'))
 
         self.assertTrue(conf.get('ovh-eu', 'non-existent') is None)
         self.assertTrue(conf.get('ovh-ca', 'application_key') is None)


### PR DESCRIPTION
Before releasing version 0.5.0 for @ncrocfer, I advise to remove mentions of runabove API. This API is no longer in use and no longer exposes any services. All customers using it have now migrated to OVH APIs (or there application stopped working long ago anyway)