### PR TITLE
Adding raw_call method to retrieve directly the vendored requests.Response object

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -388,6 +388,12 @@ class testClient(unittest.TestCase):
             # Restore configuration
             config.config = self._orig_config
 
+    @mock.patch('ovh.client.Session.request', return_value="Let's assume requests will return this")
+    def test_raw_call(self, m_req):
+        api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET)
+        r = api.raw_call(FAKE_METHOD, FAKE_PATH, None, False)
+        self.assertEqual(r, "Let's assume requests will return this")
+
     # Perform real API tests.
     def test_endpoints(self):
         for endpoint in ENDPOINTS.keys():


### PR DESCRIPTION
Signed-off-by: Geoffrey Bauduin <geoffrey.bauduin@corp.ovh.com>

The main idea here is to allow the caller to skip all the processing made on the requests response, hence allowing him to process himself the json as he wants to (that's just an example of usage, there are plenty others).