### PR TITLE
Exclude args with None value from query string

### DIFF
--- a/ovh/client.py
+++ b/ovh/client.py
@@ -316,9 +316,10 @@ class Client(object):
         arguments = {}
 
         for k, v in kwargs.items():
-            if isinstance(v, bool):
-                v = str(v).lower()
-            arguments[k] = v
+            if v is not None:
+                if isinstance(v, bool):
+                    v = str(v).lower()
+                arguments[k] = v
 
         return urlencode(arguments)
 
@@ -337,10 +338,11 @@ class Client(object):
         if kwargs:
             kwargs = self._canonicalize_kwargs(kwargs)
             query_string = self._prepare_query_string(kwargs)
-            if '?' in _target:
-                _target = '%s&%s' % (_target, query_string)
-            else:
-                _target = '%s?%s' % (_target, query_string)
+            if '=' in query_string:
+                if '?' in _target:
+                    _target = '%s&%s' % (_target, query_string)
+                else:
+                    _target = '%s?%s' % (_target, query_string)
 
         return self.call('GET', _target, None, _need_auth)
 


### PR DESCRIPTION
The following example will fail if `region` is `None`, because eventually `{ 'foo': None }` will be returned as `'foo=None'` by `urlencode()` and `'None'` is not a valid value:

```python
params = { 'region': region }                                                                                                            
flavors = client.get('/cloud/project/{}/flavor'.format(project), **params)
```
*throws:* `ovh.exceptions.BadParametersError: Invalid region parameter`

It sounds safe to me to exclude `None` values in the `client._prepare_query_string()` method because I doubt it's ever intentional to have a `NoneType` converted to the `'None'` string in this context.

---

Besides we might end up with an empty `query_string` if the original `kwargs` contained only `None` values, so I included a condition for that in a second commit to avoid the following exception:

```
Traceback (most recent call last):
(...)
  File "/lib/python3.6/site-packages/ovh/client.py", line 347, in get
    return self.call('GET', _target, None, _need_auth)
  File "/lib/python3.6/site-packages/ovh/client.py", line 446, in call
    response=result)
ovh.exceptions.BadParametersError: Invalid signature
```
`_target` was `/cloud/project/<projectid>/flavor?`