### PR TITLE
Add ResourceExpiredError exception

### DIFF
--- a/ovh/client.py
+++ b/ovh/client.py
@@ -68,6 +68,7 @@ from .exceptions import (
     APIError, NetworkError, InvalidResponse, InvalidRegion, InvalidKey,
     ResourceNotFoundError, BadParametersError, ResourceConflictError, HTTPError,
     NotGrantedCall, NotCredential, Forbidden, InvalidCredential,
+    ResourceExpiredError,
 )
 
 #: Mapping between OVH API region names and corresponding endpoints
@@ -445,6 +446,9 @@ class Client(object):
         elif status == 409:
             raise ResourceConflictError(json_result.get('message'),
                                         response=result)
+        elif status == 460:
+            raise ResourceExpiredError(json_result.get('message'),
+                                       response=result)
         elif status == 0:
             raise NetworkError()
         else:

--- a/ovh/exceptions.py
+++ b/ovh/exceptions.py
@@ -84,3 +84,6 @@ class NotCredential(APIError):
 
 class Forbidden(APIError):
     """Raised when there is an error from network layer."""
+
+class ResourceExpiredError(APIError):
+    """Raised when requested resource expired."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -43,6 +43,7 @@ from ovh.exceptions import (
     APIError, NetworkError, InvalidResponse, InvalidRegion, ReadOnlyError,
     ResourceNotFoundError, BadParametersError, ResourceConflictError, HTTPError,
     InvalidKey, InvalidCredential, NotGrantedCall, NotCredential, Forbidden,
+    ResourceExpiredError,
 )
 
 M_ENVIRON = {
@@ -298,6 +299,8 @@ class testClient(unittest.TestCase):
         self.assertRaises(BadParametersError, api.call, FAKE_METHOD, FAKE_PATH, None, False)
         m_res.status_code = 409
         self.assertRaises(ResourceConflictError, api.call, FAKE_METHOD, FAKE_PATH, None, False)
+        m_res.status_code = 460
+        self.assertRaises(ResourceExpiredError, api.call, FAKE_METHOD, FAKE_PATH, None, False)
         m_res.status_code = 0
         self.assertRaises(NetworkError, api.call, FAKE_METHOD, FAKE_PATH, None, False)
         m_res.status_code = 99


### PR DESCRIPTION
Signed-off-by: Alexandre Chaussier <alexandre.chaussier@temelio.com>

Hello,

I begin to wrote some scripts to work with your API and I've had error last days about an expired service.
To catch properly this case, I think a dedicated error can be useful.

Today, this service is not returned by the API so I don't have the return code, but I've found the toorop/ovh-cli/issues/1 issue and they catch the 460 code. I hope this have not changed.