### PR TITLE
misc(travis): auto-deploy procedure to release on PyPi from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,14 @@ install:
 script:
   - nosetests
   - python setup.py sdist bdist_wheel && pip install dist/ovh-*.tar.gz && cd /tmp && python -c 'import ovh; ovh.Client("ovh-eu").get("/auth/time", _need_auth=False)'
+deploy:
+  provider: pypi
+  user: $pypi.user
+  password: $pypi.password
+  distributions: "sdist bdist_wheel"
+  on:
+    branch: master
+    tags: true
 after_success:
     coveralls
 sudo: false


### PR DESCRIPTION
PyPi deployment procedure should be automatically trigerred by travis when commit on master is tagged with a tag.

**This requires to modify PyPi environment variable for the project to add ovh PyPi credentials for auto-deploy** 