### PR TITLE
feat(batch): add support for batch GET calls

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -66,6 +66,7 @@ FAKE_TIME = 1404395889.467238
 
 FAKE_METHOD = 'MeThOd'
 FAKE_PATH = '/unit/test'
+FAKE_PATH_BATCH = '/unit/test/1,2'
 
 TIMEOUT = 180
 
@@ -123,7 +124,7 @@ class testClient(unittest.TestCase):
 
         # nominal
         time_delta = api.time_delta
-        m_call.assert_called_once_with('GET', '/auth/time', None, False)
+        m_call.assert_called_once_with('GET', '/auth/time', None, False, None)
         self.assertEqual(time_delta, 6)
         self.assertEqual(api._time_delta, 6)
 
@@ -172,34 +173,40 @@ class testClient(unittest.TestCase):
         # basic test
         api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET, CONSUMER_KEY)
         self.assertEqual(m_call.return_value, api.get(FAKE_URL))
-        m_call.assert_called_once_with('GET', FAKE_URL, None, True)
+        m_call.assert_called_once_with('GET', FAKE_URL, None, True, None)
 
         # append query string
         m_call.reset_mock()
         api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET, CONSUMER_KEY)
         self.assertEqual(m_call.return_value, api.get(FAKE_URL, param="test"))
-        m_call.assert_called_once_with('GET', FAKE_URL+'?param=test', None, True)
+        m_call.assert_called_once_with('GET', FAKE_URL+'?param=test', None, True, None)
 
         # append to existing query string
         m_call.reset_mock()
         api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET, CONSUMER_KEY)
         self.assertEqual(m_call.return_value, api.get(FAKE_URL+'?query=string', param="test"))
-        m_call.assert_called_once_with('GET', FAKE_URL+'?query=string&param=test', None, True)
+        m_call.assert_called_once_with('GET', FAKE_URL+'?query=string&param=test', None, True, None)
 
         # boolean arguments
         m_call.reset_mock()
         api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET, CONSUMER_KEY)
         self.assertEqual(m_call.return_value, api.get(FAKE_URL+'?query=string', checkbox=True))
-        m_call.assert_called_once_with('GET', FAKE_URL+'?query=string&checkbox=true', None, True)
+        m_call.assert_called_once_with('GET', FAKE_URL+'?query=string&checkbox=true', None, True, None)
 
         # keyword calling convention
         m_call.reset_mock()
         api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET, CONSUMER_KEY)
         self.assertEqual(m_call.return_value, api.get(FAKE_URL, _from="start", to="end"))
         try:
-            m_call.assert_called_once_with('GET', FAKE_URL+'?to=end&from=start', None, True)
+            m_call.assert_called_once_with('GET', FAKE_URL+'?to=end&from=start', None, True, None)
         except:
-            m_call.assert_called_once_with('GET', FAKE_URL+'?from=start&to=end', None, True)
+            m_call.assert_called_once_with('GET', FAKE_URL+'?from=start&to=end', None, True, None)
+
+        # batch call
+        m_call.reset_mock()
+        api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET, CONSUMER_KEY)
+        self.assertEqual(m_call.return_value, api.get(FAKE_URL, _batch=','))
+        m_call.assert_called_once_with('GET', FAKE_URL, None, True, ',')
 
 
     @mock.patch.object(Client, 'call')
@@ -396,6 +403,12 @@ class testClient(unittest.TestCase):
         api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET)
         r = api.raw_call(FAKE_METHOD, FAKE_PATH, None, False)
         self.assertEqual(r, "Let's assume requests will return this")
+
+    @mock.patch('ovh.client.Session.request', return_value=["first item", "second item"])
+    def test_raw_call_batch(self, m_req):
+        api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET)
+        r = api.raw_call(FAKE_METHOD, FAKE_PATH_BATCH, None, False, ',')
+        self.assertEqual(r, ["first item", "second item"])
 
     # Perform real API tests.
     def test_endpoints(self):


### PR DESCRIPTION
This PR adds support for batch GET calls, e.g. retrieving multiple records in a single request:

`GET /domain/zone/example.com/record/123456788,123456789,...`

Batch calls require a HTTP header `X-Ovh-Batch` specifying the split character (e.g. `,`).

Signed-off-by: Pierre Kuhner pierre.kuhner@corp.ovh.com