### PR TITLE
feat: added support for headers when calling ovh.Client.raw_call

### DIFF
--- a/ovh/client.py
+++ b/ovh/client.py
@@ -471,7 +471,7 @@ class Client(object):
         else:
             raise APIError(json_result.get('message'), response=result)
 
-    def raw_call(self, method, path, data=None, need_auth=True):
+    def raw_call(self, method, path, data=None, need_auth=True, headers=None):
         """
         Lowest level call helper. If ``consumer_key`` is not ``None``, inject
         authentication headers and sign the request.
@@ -490,12 +490,17 @@ class Client(object):
         :param str path: api entrypoint to call, relative to endpoint base path
         :param data: any json serializable data to send as request's body
         :param boolean need_auth: if False, bypass signature
+        :param dict headers: A dict containing the headers that should be sent to
+                             the OVH API. ``raw_call`` will override the
+                             OVH API authentication headers, as well as
+                             the Content-Type header.
         """
         body = ''
         target = self._endpoint + path
-        headers = {
-            'X-Ovh-Application': self._application_key
-        }
+
+        if headers is None:
+            headers = {}
+        headers['X-Ovh-Application'] = self._application_key
 
         # include payload
         if data is not None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -433,6 +433,23 @@ class testClient(unittest.TestCase):
         r = api.raw_call(FAKE_METHOD, FAKE_PATH, None, False)
         self.assertEqual(r, "Let's assume requests will return this")
 
+    @mock.patch('ovh.client.Session.request', return_value="Let's assume requests will return this")
+    def test_raw_call_with_headers(self, m_req):
+        api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET)
+        r = api.raw_call(FAKE_METHOD, FAKE_PATH, None, False, headers={
+            'Custom-Header': "1",
+        })
+        self.assertEqual(r, "Let's assume requests will return this")
+        m_req.assert_called_once_with(
+            FAKE_METHOD, BASE_URL+FAKE_PATH,
+            headers={
+                'Custom-Header': "1",
+                'X-Ovh-Application': APPLICATION_KEY,
+            },
+            data='',
+            timeout=TIMEOUT
+        )
+
     # Perform real API tests.
     def test_endpoints(self):
         for endpoint in ENDPOINTS.keys():


### PR DESCRIPTION
This feature aims at making available the use of headers while calling the OVH API.
The original behavior is preserved, as the signature changes with the introduction
of a non-mandatory parameter "header", which is None by default.
Added a piece of documentation to warn the user about the possbility
to have some headers being rewritten by the Client engine.

Signed-off-by: Geoffrey Bauduin <geoffrey.bauduin@corp.ovh.com>