### PR TITLE
fix: Don't post data if no arguments were passed.

### DIFF
--- a/ovh/client.py
+++ b/ovh/client.py
@@ -487,7 +487,7 @@ class Client(object):
         }
 
         # include payload
-        if data is not None:
+        if data:
             headers['Content-type'] = 'application/json'
             body = json.dumps(data)
 


### PR DESCRIPTION
There have been some changes in the production API that make any POST call without arguments to fail with the following error:

`You provided an input body while none was expected`

This is in particular the case in the `cloud/project/{}/kube/{}/kubeconfig` call.

The `kwargs` arguments to the upstream call is passed as `data` to `raw_call()`. A check for `None` is done to prevent adding a body. This condition is never true as in the case of no arguments, `data` is not `None` but contains an empty dict. In this case, loosy testing for _falsiness_ is better.