### PR TITLE
[FIX] Using or importing the ABCs from 'collections' instead of from …

### DIFF
--- a/ovh/vendor/requests/models.py
+++ b/ovh/vendor/requests/models.py
@@ -7,7 +7,10 @@ requests.models
 This module contains the primary objects that power Requests.
 """
 
-import collections
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
 import datetime
 
 from io import BytesIO, UnsupportedOperation
@@ -165,10 +168,10 @@ class RequestHooksMixin(object):
         if event not in self.hooks:
             raise ValueError('Unsupported event specified, with event name "%s"' % (event))
 
-        if isinstance(hook, collections.Callable):
+        if isinstance(hook, Callable):
             self.hooks[event].append(hook)
         elif hasattr(hook, '__iter__'):
-            self.hooks[event].extend(h for h in hook if isinstance(h, collections.Callable))
+            self.hooks[event].extend(h for h in hook if isinstance(h, Callable))
 
     def deregister_hook(self, event, hook):
         """Deregister a previously registered hook.


### PR DESCRIPTION
…'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working