### PR TITLE
Allow to use requests package from environment

### DIFF
--- a/ovh/client.py
+++ b/ovh/client.py
@@ -46,17 +46,26 @@ except ImportError: # pragma: no cover
     # Python 3
     from urllib.parse import urlencode
 
-from .vendor.requests import request, Session
-from .vendor.requests.packages import urllib3
-from .vendor.requests.exceptions import RequestException
+try:
+    from requests import request, Session
+    from requests.packages import urllib3
+    from requests.exceptions import RequestException
+except ImportError:
+    from .vendor.requests import request, Session
+    from .vendor.requests.packages import urllib3
+    from .vendor.requests.exceptions import RequestException
 
 # Disable pyopenssl. It breaks SSL connection pool when SSL connection is
 # closed unexpectedly by the server. And we don't need SNI anyway.
 try:
-    from .vendor.requests.packages.urllib3.contrib import pyopenssl
+    from requests.packages.urllib3.contrib import pyopenssl
     pyopenssl.extract_from_urllib3()
 except ImportError:
-    pass
+    try:
+        from .vendor.requests.packages.urllib3.contrib import pyopenssl
+        pyopenssl.extract_from_urllib3()
+    except ImportError:
+        pass
 
 # Disable SNI related Warning. The API does not rely on it
 urllib3.disable_warnings(urllib3.exceptions.SNIMissingWarning)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -31,7 +31,10 @@ import mock
 import json
 from collections import OrderedDict
 
-from ovh.vendor import requests
+try:
+    import requests
+except ImportError:
+    from ovh.vendor import requests
 
 from ovh.client import Client, ENDPOINTS
 from ovh.exceptions import (


### PR DESCRIPTION
### Description 
Allow to use `requests` package from environment, if installed. Fall back on `vendors.requests` if not there.


### Why?
This is a work around for issues described in #105 #96 #98 with the included `requests` package in newer python versions.

Some `collections` imports are broken in newer python versions:
```
envs/py3/lib/python3.10/site-packages/ovh/client.py:49: in <module>
    from .vendor.requests import request, Session
envs/py3/lib/python3.10/site-packages/ovh/vendor/requests/__init__.py:58: in <module>
    from . import utils
envs/py3/lib/python3.10/site-packages/ovh/vendor/requests/utils.py:30: in <module>
    from .cookies import RequestsCookieJar, cookiejar_from_dict
envs/py3/lib/python3.10/site-packages/ovh/vendor/requests/cookies.py:164: in <module>
    class RequestsCookieJar(cookielib.CookieJar, collections.MutableMapping):
E   AttributeError: module 'collections' has no attribute 'MutableMapping'
```


### Limits
Here are a few points that should be considered before accepting this PR
1. The package will be using the `requests` package without explicitely depending on it. This could make it harder to debug issues.
2. The users will have to think of installing `requests` in their `python>=3.10` environment for things to work, instead of relying on `pip` to do it for them.

### Alternatives
Here are a few alternatives to the approach suggested in this PR
1. Upgrade the included `vendor/requests`. That will require modifying it to include requests' dependencies (charset_normalizer, idna, urllib3, certifi).
2. Introduce a requirement on `requests` instead of including it in the package. This could break existing configurations.
