### PR TITLE
Update DELETE method to support params

### DIFF
--- a/ovh/client.py
+++ b/ovh/client.py
@@ -381,14 +381,26 @@ class Client(object):
         kwargs = self._canonicalize_kwargs(kwargs)
         return self.call('POST', _target, kwargs, _need_auth)
 
-    def delete(self, _target, _need_auth=True):
+    def delete(self, _target, _need_auth=True, **kwargs):
         """
         'DELETE' :py:func:`Client.call` wrapper
+
+        Query string parameters can be set either directly in ``_target`` or as
+        keyword arguments. If an argument collides with a Python reserved
+        keyword, prefix it with a '_'. For instance, ``from`` becomes ``_from``.
 
         :param string _target: API method to call
         :param string _need_auth: If True, send authentication headers. This is
             the default
         """
+        if kwargs:
+            kwargs = self._canonicalize_kwargs(kwargs)
+            query_string = self._prepare_query_string(kwargs)
+            if '?' in _target:
+                _target = '%s&%s' % (_target, query_string)
+            else:
+                _target = '%s?%s' % (_target, query_string)
+
         return self.call('DELETE', _target, None, _need_auth)
 
     ## low level helpers

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -199,9 +199,38 @@ class testClient(unittest.TestCase):
 
     @mock.patch.object(Client, 'call')
     def test_delete(self, m_call):
+        # basic test
         api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET, CONSUMER_KEY)
         self.assertEqual(m_call.return_value, api.delete(FAKE_URL))
         m_call.assert_called_once_with('DELETE', FAKE_URL, None, True)
+
+        # append query string
+        m_call.reset_mock()
+        api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET, CONSUMER_KEY)
+        self.assertEqual(m_call.return_value, api.delete(FAKE_URL, param="test"))
+        m_call.assert_called_once_with('DELETE', FAKE_URL+'?param=test', None, True)
+
+        # append to existing query string
+        m_call.reset_mock()
+        api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET, CONSUMER_KEY)
+        self.assertEqual(m_call.return_value, api.delete(FAKE_URL+'?query=string', param="test"))
+        m_call.assert_called_once_with('DELETE', FAKE_URL+'?query=string&param=test', None, True)
+
+        # boolean arguments
+        m_call.reset_mock()
+        api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET, CONSUMER_KEY)
+        self.assertEqual(m_call.return_value, api.delete(FAKE_URL+'?query=string', checkbox=True))
+        m_call.assert_called_once_with('DELETE', FAKE_URL+'?query=string&checkbox=true', None, True)
+
+        # keyword calling convention
+        m_call.reset_mock()
+        api = Client(ENDPOINT, APPLICATION_KEY, APPLICATION_SECRET, CONSUMER_KEY)
+        self.assertEqual(m_call.return_value, api.delete(FAKE_URL, _from="start", to="end"))
+        try:
+            m_call.assert_called_once_with('DELETE', FAKE_URL+'?to=end&from=start', None, True)
+        except:
+            m_call.assert_called_once_with('DELETE', FAKE_URL+'?from=start&to=end', None, True)
+
 
     @mock.patch.object(Client, 'call')
     def test_post(self, m_call):


### PR DESCRIPTION
### Description:
Allows to specify parameters for *DELETE* requests as method parameters instead requiring to put them in url.

### Why?
Examples on [api.ovh.com](https://api.ovh.com) are broken, because method `client.delete` doesn't support parameters.
Example of broken API: `/cloud/project/{projectId}/storage/{bucketId}`