### PR TITLE
[Proposal] Migrate to HTTP Niquests

### DIFF
--- a/ovh/client.py
+++ b/ovh/client.py
@@ -38,8 +38,8 @@ import keyword
 import time
 from urllib.parse import urlencode
 
-from requests import Session
-from requests.exceptions import RequestException
+from niquests import Session
+from niquests.exceptions import RequestException
 
 from . import config
 from .consumer_key import ConsumerKeyRequest
@@ -115,6 +115,8 @@ class Client:
         consumer_key=None,
         timeout=TIMEOUT,
         config_file=None,
+        resolver=None,
+        source_address=None,
     ):
         """
         Creates a new Client. No credential check is done at this point.
@@ -134,7 +136,7 @@ class Client:
         ``timeout`` can either be a float or a tuple. If it is a float it
         sets the same timeout for both connection and read. If it is a tuple
         connection and read timeout will be set independently. To use the
-        latter approach you need at least requests v2.4.0. Default value is
+        latter approach you need at least niquests v3.0.0. Default value is
         180 seconds for connection and 180 seconds for read.
 
         :param str endpoint: API endpoint to use. Valid values in ``ENDPOINTS``
@@ -177,8 +179,8 @@ class Client:
         # lazy load time delta
         self._time_delta = None
 
-        # use a requests session to reuse HTTPS connections between requests
-        self._session = Session()
+        # use a niquests session to reuse HTTPS connections between requests
+        self._session = Session(resolver=resolver, source_address=source_address)
 
         # Override default timeout
         self._timeout = timeout
@@ -490,8 +492,8 @@ class Client:
         """
         Lowest level call helper. If ``consumer_key`` is not ``None``, inject
         authentication headers and sign the request.
-        Will return ``requests.Response`` object or let any
-        ``requests`` exception pass through.
+        Will return ``niquests.Response`` object or let any
+        ``niquests`` exception pass through.
 
         Request signature is a sha1 hash on following fields, joined by '+'
          - application_secret

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ setup_requires =
     setuptools>=30.3.0
 # requests: we need ssl+pooling fix from https://docs.python-requests.org/en/latest/community/updates/#id40
 install_requires =
-    requests>=2.11.0
+    niquests>=3.0
 include_package_data = True
 
 [options.packages.find]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -27,7 +27,7 @@
 from unittest import mock
 
 import pytest
-import requests
+import niquests
 
 from ovh.client import ENDPOINTS, Client
 from ovh.exceptions import (
@@ -213,7 +213,7 @@ class TestClient:
         api = Client("ovh-eu", application_key=MockApplicationKey)
 
         # request fails, somehow
-        m_req.side_effect = requests.RequestException
+        m_req.side_effect = niquests.RequestException
         with pytest.raises(HTTPError):
             api.call("GET", "/unauth", None, False)
         m_req.side_effect = None


### PR DESCRIPTION
Hello OVH,

I am proposing to migrate the project from Requests to the compatible Niquests.
Here a few reasons why:

- **Huge accent on the security**

This new client ship with an advanced TLS certification validation mechanism that rely on the OCSP protocol,
With this, add the capability to leverage an encrypted DNS resolver on the protocol of your choosing, like but not limited to: "DNS over HTTPS, DNS over QUIC, ...".
The TLS negotiation has been revised to be stricter, for example, denying unsafe tls renegotiation.

Also, this client no longer relies on Certifi but rather on the trusted operating system store.

- **Performance**

It is significantly faster and propose up to date protocols, mentioning it even if OVH api does seems to propose HTTP/2 or 3.
In addition to that, you can find async interfaces if needed. Also, if you decide, to offer HTTP/2+, Niquests is natively capable to leverage a multiplexed connection.

- **Compatibility**

You don't have to worry one bit about the compatibility, it is backward compatible, in fact, this project strictly extend its solid bases (requests).

---

There's a ton of improvement that you can discover at https://github.com/jawah/niquests
Also, Niquests is made in :fr: 
