### PR TITLE
Add project URLs to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,10 @@ author_email = api@ml.ovh.net
 url = https://api.ovh.com
 license = BSD
 license_file = LICENSE
+project_urls =
+    Changelog = https://github.com/ovh/python-ovh/blob/master/CHANGELOG.md
+    Repository = https://github.com/ovh/python-ovh.git
+    Issues = https://github.com/ovh/python-ovh/issues
 keywords = ovh, sdk, rest, ovhcloud
 classifiers =
     License :: OSI Approved :: BSD License


### PR DESCRIPTION
Hi :wave:

I submit a PR to add a `project_urls` section to the `setup.cfg`.

This simplifies the project discovery from PyPI.
